### PR TITLE
fix: keep focus in add word form

### DIFF
--- a/src/AddWordForm.jsx
+++ b/src/AddWordForm.jsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { X } from 'lucide-react';
+
+const AddWordForm = React.memo(({ newWord, handleNewWordChange, handleExampleChange, addNewWord, setShowAddWordForm, emojiList }) => (
+  <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+    <div className="bg-white rounded-2xl shadow-xl p-6 max-w-md w-full max-h-[90vh] overflow-y-auto">
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-2xl font-bold">Добавить новое слово</h2>
+        <button
+          onClick={() => setShowAddWordForm(false)}
+          className="p-2 hover:bg-gray-100 rounded-lg"
+        >
+          <X className="w-5 h-5" />
+        </button>
+      </div>
+
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-semibold mb-1">Английское слово *</label>
+          <input
+            type="text"
+            value={newWord.english}
+            onChange={(e) => handleNewWordChange('english', e.target.value)}
+            className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+            placeholder="Hello"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-semibold mb-1">Русский перевод *</label>
+          <input
+            type="text"
+            value={newWord.russian}
+            onChange={(e) => handleNewWordChange('russian', e.target.value)}
+            className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+            placeholder="Привет"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-semibold mb-1">Произношение</label>
+          <input
+            type="text"
+            value={newWord.pronunciation}
+            onChange={(e) => handleNewWordChange('pronunciation', e.target.value)}
+            className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+            placeholder="he-ˈloʊ"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-semibold mb-1">Категория</label>
+          <input
+            type="text"
+            value={newWord.category}
+            onChange={(e) => handleNewWordChange('category', e.target.value)}
+            className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+            placeholder="Мои слова"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-semibold mb-1">Иконка</label>
+          <div className="grid grid-cols-8 gap-2 max-h-32 overflow-y-auto p-2 border rounded-lg">
+            {emojiList.map(emoji => (
+              <button
+                key={emoji}
+                type="button"
+                onClick={() => handleNewWordChange('image', emoji)}
+                className={`text-2xl p-1 rounded hover:bg-gray-100 ${newWord.image === emoji ? 'bg-blue-100 ring-2 ring-blue-500' : ''}`}
+              >
+                {emoji}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-semibold mb-1">Примеры использования</label>
+          <input
+            type="text"
+            value={newWord.examples[0]}
+            onChange={(e) => handleExampleChange(0, e.target.value)}
+            className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 mb-2"
+            placeholder="Hello, how are you?"
+          />
+          <input
+            type="text"
+            value={newWord.examples[1]}
+            onChange={(e) => handleExampleChange(1, e.target.value)}
+            className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+            placeholder="Say hello to your friend"
+          />
+        </div>
+
+        <button
+          onClick={addNewWord}
+          disabled={!newWord.english || !newWord.russian}
+          className="w-full bg-gradient-to-r from-blue-500 to-purple-600 text-white py-3 px-6 rounded-lg hover:from-blue-600 hover:to-purple-700 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Добавить слово (+2 монеты)
+        </button>
+      </div>
+    </div>
+  </div>
+));
+
+export default AddWordForm;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { BookOpen, Trophy, Star, Clock, Target, Award, Zap, ChevronRight, X, Check, RotateCcw, Volume2, Heart, Flame, Plus, Edit2, Trash2, Save, Shuffle, PenTool, Headphones, Eye, Keyboard, ShoppingCart, BarChart3, TrendingUp, Calendar, Info, Coins, Sparkles, Palette, Music, Rocket } from 'lucide-react';
+import AddWordForm from './AddWordForm';
 
 const EnglishLearningApp = () => {
   // Начальная база слов с категориями
@@ -591,113 +592,6 @@ const EnglishLearningApp = () => {
     });
   }, []);
 
-  // Компонент формы добавления слова (мемоизирован)
-  const AddWordForm = React.memo(() => (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-2xl shadow-xl p-6 max-w-md w-full max-h-[90vh] overflow-y-auto">
-        <div className="flex justify-between items-center mb-4">
-          <h2 className="text-2xl font-bold">Добавить новое слово</h2>
-          <button
-            onClick={() => setShowAddWordForm(false)}
-            className="p-2 hover:bg-gray-100 rounded-lg"
-          >
-            <X className="w-5 h-5" />
-          </button>
-        </div>
-        
-        <div className="space-y-4">
-          <div>
-            <label className="block text-sm font-semibold mb-1">Английское слово *</label>
-            <input
-              type="text"
-              value={newWord.english}
-              onChange={(e) => handleNewWordChange('english', e.target.value)}
-              className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-              placeholder="Hello"
-            />
-          </div>
-          
-          <div>
-            <label className="block text-sm font-semibold mb-1">Русский перевод *</label>
-            <input
-              type="text"
-              value={newWord.russian}
-              onChange={(e) => handleNewWordChange('russian', e.target.value)}
-              className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-              placeholder="Привет"
-            />
-          </div>
-          
-          <div>
-            <label className="block text-sm font-semibold mb-1">Произношение</label>
-            <input
-              type="text"
-              value={newWord.pronunciation}
-              onChange={(e) => handleNewWordChange('pronunciation', e.target.value)}
-              className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-              placeholder="he-ˈloʊ"
-            />
-          </div>
-          
-          <div>
-            <label className="block text-sm font-semibold mb-1">Категория</label>
-            <input
-              type="text"
-              value={newWord.category}
-              onChange={(e) => handleNewWordChange('category', e.target.value)}
-              className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-              placeholder="Мои слова"
-            />
-          </div>
-          
-          <div>
-            <label className="block text-sm font-semibold mb-1">Иконка</label>
-            <div className="grid grid-cols-8 gap-2 max-h-32 overflow-y-auto p-2 border rounded-lg">
-              {emojiList.map(emoji => (
-                <button
-                  key={emoji}
-                  type="button"
-                  onClick={() => handleNewWordChange('image', emoji)}
-                  className={`text-2xl p-1 rounded hover:bg-gray-100 ${
-                    newWord.image === emoji ? 'bg-blue-100 ring-2 ring-blue-500' : ''
-                  }`}
-                >
-                  {emoji}
-                </button>
-              ))}
-            </div>
-          </div>
-          
-          <div>
-            <label className="block text-sm font-semibold mb-1">Примеры использования</label>
-            <input
-              type="text"
-              value={newWord.examples[0]}
-              onChange={(e) => handleExampleChange(0, e.target.value)}
-              className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 mb-2"
-              placeholder="Hello, how are you?"
-            />
-            <input
-              type="text"
-              value={newWord.examples[1]}
-              onChange={(e) => handleExampleChange(1, e.target.value)}
-              className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-              placeholder="Say hello to your friend"
-            />
-          </div>
-          
-          <button
-            onClick={addNewWord}
-            disabled={!newWord.english || !newWord.russian}
-            className="w-full bg-gradient-to-r from-blue-500 to-purple-600 text-white py-3 px-6 rounded-lg hover:from-blue-600 hover:to-purple-700 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            Добавить слово (+2 монеты)
-          </button>
-        </div>
-      </div>
-    </div>
-  ));
-
   // Компонент магазина
   const Shop = () => (
     <div className="max-w-4xl mx-auto p-6">
@@ -773,7 +667,6 @@ const EnglishLearningApp = () => {
   // Компонент статистики
   const Statistics = () => {
     const daysActive = Math.floor((Date.now() - userStats.startDate) / (1000 * 60 * 60 * 24)) || 1;
-    const averageReviewsPerDay = Math.round(userStats.totalReviews / daysActive);
     const successRate = userStats.totalReviews > 0 
       ? Math.round((words.filter(w => w.status === 'mastered').length / words.length) * 100)
       : 0;
@@ -1692,7 +1585,16 @@ const EnglishLearningApp = () => {
       </div>
       
       {/* Форма добавления слова */}
-      {showAddWordForm && <AddWordForm />}
+      {showAddWordForm && (
+        <AddWordForm
+          newWord={newWord}
+          handleNewWordChange={handleNewWordChange}
+          handleExampleChange={handleExampleChange}
+          addNewWord={addNewWord}
+          setShowAddWordForm={setShowAddWordForm}
+          emojiList={emojiList}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- extract AddWordForm into a memoized component
- wire up form through props so typing no longer blurs inputs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899a21a91288327b5b34f099a1c8f17