### PR TITLE
Add image upload, fix streak and improve word list

### DIFF
--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -1,47 +1,35 @@
 export const loadSavedData = (initialWords) => {
+  const defaultStats = {
+    level: 1,
+    xp: 0,
+    streak: 0,
+    totalWords: 0,
+    masteredWords: 0,
+    coins: 100,
+    hintsRemaining: 3,
+    purchasedItems: [],
+    activeBoosts: [],
+    currentTheme: 'default',
+    totalReviews: 0,
+    perfectDays: 0,
+    bestStreak: 0,
+    startDate: new Date().getTime(),
+    lastActiveDate: null
+  };
+
   try {
     const savedWords = localStorage.getItem('wordmaster_words');
     const savedStats = localStorage.getItem('wordmaster_stats');
 
     return {
       words: savedWords ? JSON.parse(savedWords) : initialWords,
-      stats: savedStats ? JSON.parse(savedStats) : {
-        level: 1,
-        xp: 0,
-        streak: 1,
-        totalWords: 0,
-        masteredWords: 0,
-        coins: 100,
-        hintsRemaining: 3,
-        purchasedItems: [],
-        activeBoosts: [],
-        currentTheme: 'default',
-        totalReviews: 0,
-        perfectDays: 0,
-        bestStreak: 1,
-        startDate: new Date().getTime()
-      }
+      stats: savedStats ? { ...defaultStats, ...JSON.parse(savedStats) } : defaultStats
     };
   } catch (error) {
     console.error('Error loading saved data:', error);
     return {
       words: initialWords,
-      stats: {
-        level: 1,
-        xp: 0,
-        streak: 1,
-        totalWords: 0,
-        masteredWords: 0,
-        coins: 100,
-        hintsRemaining: 3,
-        purchasedItems: [],
-        activeBoosts: [],
-        currentTheme: 'default',
-        totalReviews: 0,
-        perfectDays: 0,
-        bestStreak: 1,
-        startDate: new Date().getTime()
-      }
+      stats: defaultStats
     };
   }
 };


### PR DESCRIPTION
## Summary
- track daily streak based on last active date and save to storage
- allow enabling or disabling purchased themes and display words in statistics modals
- redesign word list as 5-column card grid with image support

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899ed6691f883278319eb935da6c3a5