### PR TITLE
Add list view toggle and mixed trainer

### DIFF
--- a/src/styles/wordStyles.css
+++ b/src/styles/wordStyles.css
@@ -1,0 +1,3 @@
+.word-card-grid {@apply bg-white rounded-lg shadow p-4 flex flex-col items-center hover:shadow-lg transition-shadow;}
+.word-card-list {@apply bg-white rounded-lg shadow p-4 flex items-center justify-between hover:shadow-lg transition-shadow;}
+.badge-base {@apply text-xs px-2 py-1 rounded-full;}


### PR DESCRIPTION
## Summary
- add list/grid view switch for words and extract shared styles
- prevent repeated cards during review by tracking dedicated list
- introduce combined training mode mixing question formats

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689aeeb4538883279bbab7554fb13fc6