### PR TITLE
Add retention levels and polish word list

### DIFF
--- a/src/data/initialWords.js
+++ b/src/data/initialWords.js
@@ -10,11 +10,11 @@ export const initialWords = [
     difficulty: 1,
     nextReview: new Date().getTime(),
     reviewCount: 0,
-    correctCount: 0,
     starred: false,
     status: 'new',
     createdAt: new Date().getTime(),
-    lastReviewed: null
+    lastReviewed: null,
+    level: 0
   },
   {
     id: 2,
@@ -27,11 +27,11 @@ export const initialWords = [
     difficulty: 1,
     nextReview: new Date().getTime(),
     reviewCount: 0,
-    correctCount: 0,
     starred: false,
     status: 'new',
     createdAt: new Date().getTime(),
-    lastReviewed: null
+    lastReviewed: null,
+    level: 0
   },
   {
     id: 3,
@@ -44,11 +44,11 @@ export const initialWords = [
     difficulty: 2,
     nextReview: new Date().getTime(),
     reviewCount: 0,
-    correctCount: 0,
     starred: false,
     status: 'new',
     createdAt: new Date().getTime(),
-    lastReviewed: null
+    lastReviewed: null,
+    level: 0
   },
   {
     id: 4,
@@ -61,11 +61,11 @@ export const initialWords = [
     difficulty: 2,
     nextReview: new Date().getTime(),
     reviewCount: 0,
-    correctCount: 0,
     starred: false,
     status: 'new',
     createdAt: new Date().getTime(),
-    lastReviewed: null
+    lastReviewed: null,
+    level: 0
   },
   {
     id: 5,
@@ -78,11 +78,11 @@ export const initialWords = [
     difficulty: 1,
     nextReview: new Date().getTime(),
     reviewCount: 0,
-    correctCount: 0,
     starred: false,
     status: 'new',
     createdAt: new Date().getTime(),
-    lastReviewed: null
+    lastReviewed: null,
+    level: 0
   }
 ];
 

--- a/src/styles/wordStyles.css
+++ b/src/styles/wordStyles.css
@@ -1,3 +1,5 @@
 .word-card-grid {@apply bg-white rounded-lg shadow p-4 flex flex-col items-center hover:shadow-lg transition-shadow;}
-.word-card-list {@apply bg-white rounded-lg shadow p-4 flex items-center justify-between hover:shadow-lg transition-shadow;}
+.word-card-list {@apply bg-white rounded-lg shadow p-4 flex items-center justify-between gap-4 hover:shadow-lg transition-shadow;}
 .badge-base {@apply text-xs px-2 py-1 rounded-full;}
+.progress-bar {@apply w-24 h-2 bg-gray-200 rounded-full overflow-hidden;}
+.progress-bar-fill {@apply h-full bg-green-500;}

--- a/src/utils/calculateNextReview.js
+++ b/src/utils/calculateNextReview.js
@@ -1,26 +1,18 @@
-export const calculateNextReview = (word, correct) => {
-  const intervals = [
-    1000 * 60 * 10,
-    1000 * 60 * 60,
-    1000 * 60 * 60 * 6,
-    1000 * 60 * 60 * 24,
-    1000 * 60 * 60 * 24 * 3,
-    1000 * 60 * 60 * 24 * 7,
-    1000 * 60 * 60 * 24 * 14,
-    1000 * 60 * 60 * 24 * 30,
-    1000 * 60 * 60 * 24 * 90
-  ];
+export const reviewIntervals = [
+  1000 * 60 * 10, // 10 minutes
+  1000 * 60 * 60, // 1 hour
+  1000 * 60 * 60 * 6, // 6 hours
+  1000 * 60 * 60 * 24, // 1 day
+  1000 * 60 * 60 * 24 * 3, // 3 days
+  1000 * 60 * 60 * 24 * 7, // 1 week
+  1000 * 60 * 60 * 24 * 14, // 2 weeks
+  1000 * 60 * 60 * 24 * 30, // 1 month
+  1000 * 60 * 60 * 24 * 90 // 3 months
+];
 
-  let nextInterval;
-
-  if (correct) {
-    const nextIndex = Math.min(word.correctCount, intervals.length - 1);
-    nextInterval = intervals[nextIndex];
-  } else {
-    nextInterval = intervals[0];
-  }
-
-  return new Date().getTime() + nextInterval;
+export const calculateNextReview = (level) => {
+  const index = Math.min(level, reviewIntervals.length - 1);
+  return Date.now() + reviewIntervals[index];
 };
 
 export default calculateNextReview;

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -21,8 +21,9 @@ export const loadSavedData = (initialWords) => {
     const savedWords = localStorage.getItem('wordmaster_words');
     const savedStats = localStorage.getItem('wordmaster_stats');
 
+    const parsedWords = (savedWords ? JSON.parse(savedWords) : initialWords).map(w => ({ level: 0, ...w }));
     return {
-      words: savedWords ? JSON.parse(savedWords) : initialWords,
+      words: parsedWords,
       stats: savedStats ? { ...defaultStats, ...JSON.parse(savedStats) } : defaultStats
     };
   } catch (error) {


### PR DESCRIPTION
## Summary
- track per-word retention level with spaced repetition intervals
- show level progress with polished styles in word lists and modal
- persist new level data in local storage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689af51efe74832785844c34c4a89ce0