### PR TITLE
Refine word views and category handling

### DIFF
--- a/src/AddWordForm.jsx
+++ b/src/AddWordForm.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { X } from 'lucide-react';
 
-const AddWordForm = React.memo(({ newWord, handleNewWordChange, handleExampleChange, addNewWord, setShowAddWordForm, emojiList, handleImageUpload }) => (
+const AddWordForm = React.memo(({ newWord, handleNewWordChange, handleExampleChange, addNewWord, setShowAddWordForm, emojiList, handleImageUpload, categories }) => (
   <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
     <div className="bg-white rounded-2xl shadow-xl p-6 max-w-md w-full max-h-[90vh] overflow-y-auto">
       <div className="flex justify-between items-center mb-4">
@@ -50,13 +50,15 @@ const AddWordForm = React.memo(({ newWord, handleNewWordChange, handleExampleCha
 
         <div>
           <label className="block text-sm font-semibold mb-1">Категория</label>
-          <input
-            type="text"
+          <select
             value={newWord.category}
             onChange={(e) => handleNewWordChange('category', e.target.value)}
             className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-            placeholder="Мои слова"
-          />
+          >
+            {categories.map(cat => (
+              <option key={cat} value={cat}>{cat}</option>
+            ))}
+          </select>
         </div>
 
         <div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { BookOpen, Trophy, Star, Clock, Target, Award, Zap, X, Check, RotateCcw, Volume2, Heart, Flame, Plus, Edit2, Save, Shuffle, PenTool, Headphones, Eye, Keyboard, ShoppingCart, BarChart3, TrendingUp, Calendar, Info, Coins, Sparkles, Palette, Music, Rocket } from 'lucide-react';
+import { BookOpen, Trophy, Clock, Target, Award, Zap, X, Check, RotateCcw, Volume2, Heart, Flame, Plus, Edit2, Save, Shuffle, PenTool, Headphones, Eye, Keyboard, ShoppingCart, BarChart3, TrendingUp, Calendar, Info, Coins, Sparkles, Palette, Music, Rocket } from 'lucide-react';
 import './styles/word-page.css';
 import AddWordForm from './AddWordForm';
 import WordsList from './WordsList';
@@ -9,9 +9,12 @@ import { loadSavedData, saveWords, saveStats } from './utils/storage';
 import { formatDate } from './utils/formatDate';
 import { calculateNextReview, reviewIntervals } from './utils/calculateNextReview';
 
+const categoryOptions = ['Путешествия', 'Природа', 'Эмоции', 'Образование', 'Технологии', 'Еда', 'Дом', 'Животные'];
+
   const App = () => {
   const savedData = loadSavedData(initialWords);
   const maxLevel = reviewIntervals.length;
+  const categories = ['all', ...categoryOptions];
   const [words, setWords] = useState(savedData.words);
   const [currentView, setCurrentView] = useState('dashboard');
   const [selectedCategory, setSelectedCategory] = useState('all');
@@ -34,7 +37,7 @@ import { calculateNextReview, reviewIntervals } from './utils/calculateNextRevie
   const [newWord, setNewWord] = useState({
     english: '',
     russian: '',
-    category: '',
+    category: categoryOptions[0],
     image: '📝',
     examples: ['', ''],
     pronunciation: ''
@@ -94,14 +97,10 @@ import { calculateNextReview, reviewIntervals } from './utils/calculateNextRevie
   useEffect(() => {
     saveStats(userStats);
   }, [userStats]);
-
-  // Получить уникальные категории
-  const categories = useMemo(() => ['all', ...new Set(words.map(w => w.category))], [words]);
-
   // Фильтрация слов по категории
-  const filteredWords = useMemo(() => 
-    selectedCategory === 'all' 
-      ? words 
+  const filteredWords = useMemo(() =>
+    selectedCategory === 'all'
+      ? words
       : words.filter(w => w.category === selectedCategory),
     [words, selectedCategory]
   );
@@ -211,13 +210,6 @@ import { calculateNextReview, reviewIntervals } from './utils/calculateNextRevie
     }, 1000);
   }, [words, reviewWords, currentCardIndex, userStats.activeBoosts, updateWordProgress]);
 
-  // Переключение закрепленных слов
-  const toggleStar = useCallback((wordId) => {
-    setWords(prev => prev.map(w => 
-      w.id === wordId ? { ...w, starred: !w.starred } : w
-    ));
-  }, []);
-
   // Удаление слова
   const deleteWord = useCallback((wordId) => {
     if (window.confirm('Вы уверены, что хотите удалить это слово?')) {
@@ -249,8 +241,8 @@ import { calculateNextReview, reviewIntervals } from './utils/calculateNextRevie
       setNewWord({
         english: '',
         russian: '',
-        category: '',
-        image: '',
+        category: categoryOptions[0],
+        image: '📝',
         examples: ['', ''],
         pronunciation: ''
       });
@@ -616,14 +608,6 @@ import { calculateNextReview, reviewIntervals } from './utils/calculateNextRevie
           <span className="text-6xl">{word.image}</span>
         )}
         <div className="flex flex-col items-end gap-2">
-          <button
-            onClick={() => toggleStar(word.id)}
-            className={`p-2 rounded-full transition-colors ${
-              word.starred ? 'bg-yellow-100 text-yellow-600' : 'bg-gray-100 text-gray-400'
-            }`}
-          >
-            <Star className={`w-5 h-5 ${word.starred ? 'fill-current' : ''}`} />
-          </button>
           <span className="text-xs text-gray-500">
             Повтор {formatDate(word.nextReview)}
           </span>
@@ -1131,33 +1115,28 @@ import { calculateNextReview, reviewIntervals } from './utils/calculateNextRevie
         </div>
         <ul className="space-y-2">
           {modal.words.map(w => (
-            <li key={w.id} className="word-card-list">
-              <div className="word-left">
-                <div className="word-media">
-                  {typeof w.image === 'string' && (w.image.startsWith('http') || w.image.startsWith('data:')) ? (
-                    <img src={w.image} alt={w.english} className="h-full w-full object-cover" />
-                  ) : (
-                    <span className="text-2xl grid place-items-center h-full w-full">{w.image}</span>
-                  )}
-                </div>
-                <div className="min-w-0">
-                  <p className="word-title">{w.english}</p>
-                  <p className="word-subtitle">{w.russian}</p>
-                </div>
-              </div>
-              <div className="word-right">
-                <div className="flex items-center justify-center gap-2 self-center w-full">
-                  <div className="progress-bar">
-                    <div className="progress-bar-fill" style={{ width: `${(w.level / maxLevel) * 100}%` }} />
+              <li key={w.id} className="word-card-list">
+                <div className="word-left">
+                  <div className="word-media">
+                    {typeof w.image === 'string' && (w.image.startsWith('http') || w.image.startsWith('data:')) ? (
+                      <img src={w.image} alt={w.english} className="h-full w-full object-cover" />
+                    ) : (
+                      <span className="text-2xl grid place-items-center h-full w-full">{w.image}</span>
+                    )}
                   </div>
-                  <span className="text-xs text-slate-500">{w.level}/{maxLevel}</span>
+                  <div className="min-w-0">
+                    <p className="word-title">{w.english}</p>
+                  </div>
                 </div>
-                <div className="flex flex-wrap justify-end gap-2">
-                  <span className="badge-base badge-cat">{w.category}</span>
-                  <span className="badge-base badge-repeat">Повтор {formatDate(w.nextReview)}</span>
+                <div className="word-right">
+                  <div className="flex items-center justify-center gap-2 self-center w-full">
+                    <div className="progress-bar">
+                      <div className="progress-bar-fill" style={{ width: `${(w.level / maxLevel) * 100}%` }} />
+                    </div>
+                    <span className="text-xs text-slate-500">{w.level}/{maxLevel}</span>
+                  </div>
                 </div>
-              </div>
-            </li>
+              </li>
           ))}
         </ul>
       </div>
@@ -1497,7 +1476,6 @@ import { calculateNextReview, reviewIntervals } from './utils/calculateNextRevie
             setSelectedCategory={setSelectedCategory}
             filteredWords={filteredWords}
             maxLevel={maxLevel}
-            toggleStar={toggleStar}
             deleteWord={deleteWord}
             setCurrentCardIndex={setCurrentCardIndex}
             setReviewWords={setReviewWords}
@@ -1550,6 +1528,7 @@ import { calculateNextReview, reviewIntervals } from './utils/calculateNextRevie
           setShowAddWordForm={setShowAddWordForm}
           emojiList={emojiList}
           handleImageUpload={handleImageUpload}
+          categories={categoryOptions}
         />
       )}
     </div>

--- a/src/WordsList.jsx
+++ b/src/WordsList.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Star, Trash2, ChevronRight, Plus, LayoutGrid, List } from 'lucide-react';
+import { Trash2, ChevronRight, Plus, LayoutGrid, List } from 'lucide-react';
 import { formatDate } from './utils/formatDate';
 
 const WordsList = ({
@@ -8,7 +8,6 @@ const WordsList = ({
   setSelectedCategory,
   filteredWords,
   maxLevel,
-  toggleStar,
   deleteWord,
   setCurrentCardIndex,
   setReviewWords,
@@ -17,7 +16,7 @@ const WordsList = ({
   setShowAddWordForm,
   onWordClick,
 }) => {
-  const [viewMode, setViewMode] = useState('list');
+  const [viewMode, setViewMode] = useState('grid');
 
   const renderGridItem = (word) => (
     <div
@@ -48,15 +47,6 @@ const WordsList = ({
         <span className="badge-base badge-repeat">Повтор {formatDate(word.nextReview)}</span>
       </div>
       <div className="word-actions justify-center">
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            toggleStar(word.id);
-          }}
-          className={`icon-btn ${word.starred ? 'bg-yellow-50 text-yellow-600 hover:bg-yellow-100' : ''}`}
-        >
-          <Star className={`w-5 h-5 ${word.starred ? 'fill-current' : ''}`} />
-        </button>
         <button
           onClick={(e) => {
             e.stopPropagation();
@@ -108,23 +98,12 @@ const WordsList = ({
           </div>
           <span className="text-xs text-slate-500">{word.level}/{maxLevel}</span>
         </div>
-        <div className="flex flex-wrap justify-end gap-2">
+        <div className="flex flex-wrap items-center justify-end gap-2">
           <span className={`badge-base badge-status-${word.status}`}>
             {word.status === 'mastered' ? 'Изучено' : word.status === 'learning' ? 'На изучении' : 'Новое'}
           </span>
           <span className="badge-base badge-cat">{word.category}</span>
           <span className="badge-base badge-repeat">Повтор {formatDate(word.nextReview)}</span>
-        </div>
-        <div className="word-actions">
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              toggleStar(word.id);
-            }}
-            className={`icon-btn ${word.starred ? 'bg-yellow-50 text-yellow-600 hover:bg-yellow-100' : ''}`}
-          >
-            <Star className={`w-5 h-5 ${word.starred ? 'fill-current' : ''}`} />
-          </button>
           <button
             onClick={(e) => {
               e.stopPropagation();
@@ -134,6 +113,8 @@ const WordsList = ({
           >
             <Trash2 className="w-5 h-5" />
           </button>
+        </div>
+        <div className="word-actions">
           <button
             onClick={(e) => {
               e.stopPropagation();
@@ -155,20 +136,18 @@ const WordsList = ({
     <div className="word-page">
       <div className="max-w-4xl mx-auto p-6">
         <div className="mb-6 flex justify-between items-center">
-          <div className="flex flex-wrap gap-2">
-            {categories.map(cat => (
-              <button
-                key={cat}
-                onClick={() => setSelectedCategory(cat)}
-                className={`px-4 py-2 rounded-lg transition-colors ${
-                  selectedCategory === cat
-                    ? 'bg-blue-500 text-white'
-                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-                }`}
-              >
-                {cat === 'all' ? 'Все' : cat}
-              </button>
-            ))}
+          <div>
+            <select
+              value={selectedCategory}
+              onChange={(e) => setSelectedCategory(e.target.value)}
+              className="px-4 py-2 rounded-lg bg-gray-100 text-gray-700"
+            >
+              {categories.map(cat => (
+                <option key={cat} value={cat}>
+                  {cat === 'all' ? 'Все' : cat}
+                </option>
+              ))}
+            </select>
           </div>
 
           <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- default word list view switched to grid with optional list toggle
- streamline lists by removing star controls and reducing dashboard word info
- introduce predefined categories with dropdowns for filtering and new word entry

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b0d2923748327a51ca1a8976954a6