### PR TITLE
Fix word persistence after refresh

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -221,7 +221,11 @@ const categoryOptions = ['Путешествия', 'Природа', 'Эмоци
   // Удаление слова
   const deleteWord = useCallback((wordId) => {
     if (window.confirm('Вы уверены, что хотите удалить это слово?')) {
-      setWords(prev => prev.filter(w => w.id !== wordId));
+      setWords(prev => {
+        const updated = prev.filter(w => w.id !== wordId);
+        saveWords(updated);
+        return updated;
+      });
     }
   }, []);
 
@@ -244,8 +248,12 @@ const categoryOptions = ['Путешествия', 'Природа', 'Эмоци
         createdAt: new Date().getTime(),
         lastReviewed: null
       };
-      
-      setWords(prev => [...prev, word]);
+
+      setWords(prev => {
+        const updated = [...prev, word];
+        saveWords(updated);
+        return updated;
+      });
       setNewWord({
         english: '',
         russian: '',


### PR DESCRIPTION
## Summary
- save updated words list to localStorage when adding or deleting words

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b3153be6c83279847aa5b8227b767