### PR TITLE
feat: add custom categories and availability styling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,15 +5,16 @@ import AddWordForm from './AddWordForm';
 import WordsList from './WordsList';
 import { initialWords } from './data/initialWords';
 import { shopItems } from './data/shopItems';
-import { loadSavedData, saveWords, saveStats } from './utils/storage';
+import { loadSavedData, saveWords, saveStats, loadCategories, saveCategories } from './utils/storage';
 import { formatDate } from './utils/formatDate';
 import { calculateNextReview, reviewIntervals } from './utils/calculateNextReview';
 
-const categoryOptions = ['Путешествия', 'Природа', 'Эмоции', 'Образование', 'Технологии', 'Еда', 'Дом', 'Животные'];
+const defaultCategories = ['Разное', 'Путешествия', 'Природа', 'Эмоции', 'Образование', 'Технологии', 'Еда', 'Дом', 'Животные'];
 
   const App = () => {
   const savedData = loadSavedData(initialWords);
   const maxLevel = reviewIntervals.length;
+  const [categoryOptions, setCategoryOptions] = useState(() => loadCategories(defaultCategories));
   const categories = ['all', ...categoryOptions];
   const [words, setWords] = useState(savedData.words);
   const [currentView, setCurrentView] = useState('dashboard');
@@ -104,6 +105,10 @@ const categoryOptions = ['Путешествия', 'Природа', 'Эмоци
   useEffect(() => {
     saveStats(userStats);
   }, [userStats]);
+
+  useEffect(() => {
+    saveCategories(categoryOptions);
+  }, [categoryOptions]);
   // Фильтрация слов по категории
   const filteredWords = useMemo(() =>
     selectedCategory === 'all'
@@ -122,6 +127,13 @@ const categoryOptions = ['Путешествия', 'Природа', 'Эмоци
     words.filter(w => w.reviewCount === 0),
     [words]
   );
+
+  const addCategory = () => {
+    const name = prompt('Введите название категории');
+    if (name && !categoryOptions.includes(name)) {
+      setCategoryOptions(prev => [...prev, name]);
+    }
+  };
 
   // Покупка/активация предметов в магазине
   const purchaseItem = useCallback((item) => {
@@ -235,7 +247,7 @@ const categoryOptions = ['Путешествия', 'Природа', 'Эмоци
       const word = {
         ...newWord,
         id: Date.now(),
-        category: newWord.category || 'Мои слова',
+        category: newWord.category || 'Разное',
         image: newWord.image || '📝',
         examples: newWord.examples.filter(ex => ex.length > 0),
         difficulty: 1,
@@ -1325,7 +1337,14 @@ const categoryOptions = ['Путешествия', 'Природа', 'Эмоци
         </div>
         <ul className="space-y-2">
           {modal.words.map(w => (
-              <li key={w.id} className="word-card-list">
+              <li
+                key={w.id}
+                className="word-card-list cursor-pointer"
+                onClick={() => {
+                  setSelectedWord(w);
+                  onClose();
+                }}
+              >
                 <div className="word-left">
                   <div className="word-media">
                     {typeof w.image === 'string' && (w.image.startsWith('http') || w.image.startsWith('data:')) ? (
@@ -1641,6 +1660,7 @@ const categoryOptions = ['Путешествия', 'Природа', 'Эмоци
             setShowAnswer={setShowAnswer}
             setShowAddWordForm={setShowAddWordForm}
             onWordClick={setSelectedWord}
+            addCategory={addCategory}
           />
         )}
         {currentView === 'shop' && <Shop />}

--- a/src/WordsList.jsx
+++ b/src/WordsList.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Trash2, ChevronRight, Plus, LayoutGrid, List } from 'lucide-react';
+import { Trash2, ChevronRight, Plus, LayoutGrid, List, FolderPlus } from 'lucide-react';
 import { formatDate } from './utils/formatDate';
 
 const WordsList = ({
@@ -15,13 +15,16 @@ const WordsList = ({
   setShowAnswer,
   setShowAddWordForm,
   onWordClick,
+  addCategory,
 }) => {
   const [viewMode, setViewMode] = useState('grid');
 
   const renderGridItem = (word) => {
-    const repeatText = word.nextReview > Date.now()
-      ? `Будет доступно ${formatDate(word.nextReview)}`
-      : 'Доступно';
+    const isAvailable = word.nextReview <= Date.now();
+    const repeatText = isAvailable
+      ? 'Доступно'
+      : `Будет доступно ${formatDate(word.nextReview)}`;
+    const repeatClass = isAvailable ? 'badge-available' : 'badge-repeat';
     return (
       <div
         key={word.id}
@@ -49,7 +52,7 @@ const WordsList = ({
               {word.status === 'mastered' ? 'Изучено' : 'Новое'}
             </span>
           )}
-          <span className="badge-base badge-repeat">{repeatText}</span>
+          <span className={`badge-base ${repeatClass}`}>{repeatText}</span>
         </div>
         <div className="word-actions justify-center">
           <button
@@ -79,9 +82,11 @@ const WordsList = ({
   };
 
   const renderListItem = (word) => {
-    const repeatText = word.nextReview > Date.now()
-      ? `Будет доступно ${formatDate(word.nextReview)}`
-      : 'Доступно';
+    const isAvailable = word.nextReview <= Date.now();
+    const repeatText = isAvailable
+      ? 'Доступно'
+      : `Будет доступно ${formatDate(word.nextReview)}`;
+    const repeatClass = isAvailable ? 'badge-available' : 'badge-repeat';
     return (
       <div
         key={word.id}
@@ -96,49 +101,45 @@ const WordsList = ({
               <span className="text-2xl grid place-items-center h-full w-full">{word.image}</span>
             )}
           </div>
-          <div className="min-w-0">
+          <div className="flex items-center gap-2 min-w-0">
             <h3 className="word-title truncate">{word.english}</h3>
             <p className="word-subtitle truncate">{word.russian}</p>
           </div>
         </div>
         <div className="word-right">
-          <div className="flex items-center justify-center gap-2 self-center w-full">
+          <div className="flex items-center gap-2">
             <div className="progress-bar">
               <div className="progress-bar-fill" style={{ width: `${(word.level / maxLevel) * 100}%` }} />
             </div>
             <span className="text-xs text-slate-500">{word.level}/{maxLevel}</span>
           </div>
-          <div className="flex flex-wrap items-center justify-end gap-2">
-            {word.status !== 'learning' && (
-              <span className={`badge-base badge-status-${word.status}`}>
-                {word.status === 'mastered' ? 'Изучено' : 'Новое'}
-              </span>
-            )}
-            <span className="badge-base badge-repeat">{repeatText}</span>
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                deleteWord(word.id);
-              }}
-              className="icon-btn icon-danger"
-            >
-              <Trash2 className="w-5 h-5" />
-            </button>
-          </div>
-          <div className="word-actions">
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                setCurrentCardIndex(filteredWords.findIndex(w => w.id === word.id));
-                setReviewWords(filteredWords);
-                setCurrentView('cards');
-                setShowAnswer(false);
-              }}
-              className="icon-btn icon-primary"
-            >
-              <ChevronRight className="w-5 h-5" />
-            </button>
-          </div>
+          {word.status !== 'learning' && (
+            <span className={`badge-base badge-status-${word.status}`}>
+              {word.status === 'mastered' ? 'Изучено' : 'Новое'}
+            </span>
+          )}
+          <span className={`badge-base ${repeatClass}`}>{repeatText}</span>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              deleteWord(word.id);
+            }}
+            className="icon-btn icon-danger"
+          >
+            <Trash2 className="w-5 h-5" />
+          </button>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              setCurrentCardIndex(filteredWords.findIndex(w => w.id === word.id));
+              setReviewWords(filteredWords);
+              setCurrentView('cards');
+              setShowAnswer(false);
+            }}
+            className="icon-btn icon-primary"
+          >
+            <ChevronRight className="w-5 h-5" />
+          </button>
         </div>
       </div>
     );
@@ -148,7 +149,7 @@ const WordsList = ({
     <div className="word-page">
       <div className="max-w-4xl mx-auto p-6">
         <div className="mb-6 flex justify-between items-center">
-          <div>
+          <div className="flex items-center gap-2">
             <select
               value={selectedCategory}
               onChange={(e) => setSelectedCategory(e.target.value)}
@@ -160,6 +161,12 @@ const WordsList = ({
                 </option>
               ))}
             </select>
+            <button
+              onClick={addCategory}
+              className="p-2 rounded-lg bg-gray-100 hover:bg-gray-200"
+            >
+              <FolderPlus className="w-5 h-5" />
+            </button>
           </div>
 
           <div className="flex items-center gap-2">

--- a/src/styles/word-page.css
+++ b/src/styles/word-page.css
@@ -85,8 +85,8 @@
 
 .word-right {
   display: flex;
-  flex-direction: column;
-  align-items: flex-end;
+  align-items: center;
+  justify-content: flex-end;
   gap: 0.5rem;
   min-width: 40%;
 }
@@ -131,6 +131,11 @@
 .badge-repeat {
   background-color: #f5f3ff;
   color: #5b21b6;
+}
+
+.badge-available {
+  background-color: #f0fdf4;
+  color: #15803d;
 }
 .badge-ghost {
   background-color: #f1f5f9;

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -50,3 +50,21 @@ export const saveStats = (stats) => {
     console.error('Error saving stats:', error);
   }
 };
+
+export const loadCategories = (defaults) => {
+  try {
+    const saved = localStorage.getItem('wordmaster_categories');
+    return saved ? JSON.parse(saved) : defaults;
+  } catch (error) {
+    console.error('Error loading categories:', error);
+    return defaults;
+  }
+};
+
+export const saveCategories = (categories) => {
+  try {
+    localStorage.setItem('wordmaster_categories', JSON.stringify(categories));
+  } catch (error) {
+    console.error('Error saving categories:', error);
+  }
+};


### PR DESCRIPTION
## Summary
- allow creating custom categories with default "Разное" and persist them
- color available words with green badge and align list view horizontally
- make dashboard word lists open word details when clicked

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b36f9927c8327a4070949942f7e57