### PR TITLE
feat: auto-generate words and improve list layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import AddWordForm from './AddWordForm';
 import WordsList from './WordsList';
 import { initialWords } from './data/initialWords';
 import { shopItems } from './data/shopItems';
+import { autoWords } from './data/autoWords';
 import { loadSavedData, saveWords, saveStats, loadCategories, saveCategories } from './utils/storage';
 import { formatDate } from './utils/formatDate';
 import { calculateNextReview, reviewIntervals } from './utils/calculateNextReview';
@@ -93,9 +94,15 @@ const defaultCategories = ['Разное', 'Путешествия', 'Приро
   }, []);
 
   // Список эмодзи для выбора
-  const emojiList = ['📝', '🌟', '🌈', '🔥', '💡', '🎨', '🎭', '🎪', '🎯', '🎲', '🎸', '🎹', '🏆', '🚀', '✨', '💎', '🌺', '🌸',
- '🌼', '🌻', '🌷', '🌹', '🍀', '🌲', '🌳', '🌴', '🌵', '🌊', '⛰️', '🏔️', '🌋', '🏝️', '🏖️', '🌅', '🌄', '🌠', '🌌', '☀️', '🌙', '⭐',
- '☁️', '⛅', '🌤️', '🌥️', '🌦️', '🌧️', '⛈️', '❄️', '☃️', '🌨️'];
+  const emojiList = [
+    '📝', '🌟', '🌈', '🔥', '💡', '🎨', '🎭', '🎪', '🎯', '🎲', '🎸', '🎹', '🏆', '🚀', '✨', '💎',
+    '🌺', '🌸', '🌼', '🌻', '🌷', '🌹', '🍀', '🌲', '🌳', '🌴', '🌵', '🌊', '⛰️', '🏔️', '🌋',
+    '🏝️', '🏖️', '🌅', '🌄', '🌠', '🌌', '☀️', '🌙', '⭐', '☁️', '⛅', '🌤️', '🌥️', '🌦️',
+    '🌧️', '⛈️', '❄️', '☃️', '🌨️', '🐶', '🐱', '🐭', '🐹', '🐰', '🦊', '🐻', '🐼', '🐨',
+    '🐯', '🦁', '🐮', '🐷', '🐸', '🐵', '🐦', '🐤', '🐧', '🦅', '🦆', '🦉', '🐺', '🐗',
+    '🐴', '🦄', '🐝', '🦋', '🐌', '🐞', '🐢', '🐍', '🐙', '🦑', '🦀', '🐠', '🐟', '🐡',
+    '🐬', '🐳', '🦈', '🌍', '🌎', '🌏', '⚡', '🎁', '📚', '📱', '💻', '⌚'
+  ];
 
   // Сохранение данных в localStorage
   useEffect(() => {
@@ -283,6 +290,34 @@ const defaultCategories = ['Разное', 'Путешествия', 'Приро
       }));
     }
   }, [newWord]);
+
+  // Автогенерация слова
+  const generateAutoWord = useCallback(() => {
+    const available = autoWords.filter(t =>
+      !words.some(w => w.english.toLowerCase() === t.english.toLowerCase())
+    );
+    if (available.length === 0) return;
+    const template = available[Math.floor(Math.random() * available.length)];
+    const word = {
+      ...template,
+      id: Date.now(),
+      difficulty: 1,
+      nextReview: Date.now(),
+      reviewCount: 0,
+      errorCount: 0,
+      level: 0,
+      starred: false,
+      status: 'new',
+      createdAt: Date.now(),
+      lastReviewed: null,
+    };
+    setWords(prev => {
+      const updated = [...prev, word];
+      saveWords(updated);
+      return updated;
+    });
+    setUserStats(prev => ({ ...prev, coins: prev.coins + 2 }));
+  }, [words]);
 
   // Генерация вопроса для тренажера
   const generateQuestion = useCallback((task) => {
@@ -1661,6 +1696,7 @@ const defaultCategories = ['Разное', 'Путешествия', 'Приро
             setShowAddWordForm={setShowAddWordForm}
             onWordClick={setSelectedWord}
             addCategory={addCategory}
+            generateWord={generateAutoWord}
           />
         )}
         {currentView === 'shop' && <Shop />}

--- a/src/WordsList.jsx
+++ b/src/WordsList.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Trash2, ChevronRight, Plus, LayoutGrid, List, FolderPlus } from 'lucide-react';
+import { Trash2, ChevronRight, Plus, LayoutGrid, List, FolderPlus, Wand2 } from 'lucide-react';
 import { formatDate } from './utils/formatDate';
 
 const WordsList = ({
@@ -16,6 +16,7 @@ const WordsList = ({
   setShowAddWordForm,
   onWordClick,
   addCategory,
+  generateWord,
 }) => {
   const [viewMode, setViewMode] = useState('grid');
 
@@ -81,6 +82,40 @@ const WordsList = ({
     );
   };
 
+  const ProgressCircle = ({ level }) => {
+    const radius = 16;
+    const circumference = 2 * Math.PI * radius;
+    const progress = level / maxLevel;
+    return (
+      <div className="relative w-10 h-10">
+        <svg className="w-10 h-10 transform -rotate-90">
+          <circle
+            cx="20"
+            cy="20"
+            r={radius}
+            strokeWidth="4"
+            className="text-gray-200"
+            stroke="currentColor"
+            fill="none"
+          />
+          <circle
+            cx="20"
+            cy="20"
+            r={radius}
+            strokeWidth="4"
+            strokeLinecap="round"
+            className="text-blue-500"
+            strokeDasharray={circumference}
+            strokeDashoffset={circumference - progress * circumference}
+            stroke="currentColor"
+            fill="none"
+          />
+        </svg>
+        <span className="absolute inset-0 flex items-center justify-center text-xs">{level}</span>
+      </div>
+    );
+  };
+
   const renderListItem = (word) => {
     const isAvailable = word.nextReview <= Date.now();
     const repeatText = isAvailable
@@ -94,6 +129,7 @@ const WordsList = ({
         onClick={() => onWordClick(word)}
       >
         <div className="word-left">
+          <ProgressCircle level={word.level} />
           <div className="word-media">
             {typeof word.image === 'string' && (word.image.startsWith('http') || word.image.startsWith('data:')) ? (
               <img src={word.image} alt={word.english} className="h-full w-full object-cover" />
@@ -101,18 +137,12 @@ const WordsList = ({
               <span className="text-2xl grid place-items-center h-full w-full">{word.image}</span>
             )}
           </div>
-          <div className="flex items-center gap-2 min-w-0">
+          <div className="flex flex-col min-w-0">
             <h3 className="word-title truncate">{word.english}</h3>
             <p className="word-subtitle truncate">{word.russian}</p>
           </div>
         </div>
         <div className="word-right">
-          <div className="flex items-center gap-2">
-            <div className="progress-bar">
-              <div className="progress-bar-fill" style={{ width: `${(word.level / maxLevel) * 100}%` }} />
-            </div>
-            <span className="text-xs text-slate-500">{word.level}/{maxLevel}</span>
-          </div>
           {word.status !== 'learning' && (
             <span className={`badge-base badge-status-${word.status}`}>
               {word.status === 'mastered' ? 'Изучено' : 'Новое'}
@@ -175,6 +205,13 @@ const WordsList = ({
               className="p-2 rounded-lg bg-gray-100 hover:bg-gray-200"
             >
               {viewMode === 'list' ? <LayoutGrid className="w-5 h-5" /> : <List className="w-5 h-5" />}
+            </button>
+            <button
+              onClick={generateWord}
+              className="bg-blue-500 text-white px-4 py-2 rounded-lg hover:bg-blue-600 transition-colors flex items-center gap-2"
+            >
+              <Wand2 className="w-5 h-5" />
+              Сгенерировать
             </button>
             <button
               onClick={() => setShowAddWordForm(true)}

--- a/src/data/autoWords.js
+++ b/src/data/autoWords.js
@@ -1,0 +1,84 @@
+export const autoWords = [
+  {
+    english: 'Sunrise',
+    russian: 'Рассвет',
+    category: 'Природа',
+    image: '🌅',
+    examples: ['The sunrise is beautiful', 'We woke up at sunrise'],
+    pronunciation: 'ˈsʌnˌraɪz'
+  },
+  {
+    english: 'Friendship',
+    russian: 'Дружба',
+    category: 'Отношения',
+    image: '🤝',
+    examples: ['Our friendship is strong', 'Friendship is important'],
+    pronunciation: 'ˈfrɛndʃɪp'
+  },
+  {
+    english: 'Algorithm',
+    russian: 'Алгоритм',
+    category: 'Технологии',
+    image: '🤖',
+    examples: ['This algorithm is complex', 'Learning algorithms can be fun'],
+    pronunciation: 'ˈælɡəˌrɪðəm'
+  },
+  {
+    english: 'Painting',
+    russian: 'Живопись',
+    category: 'Искусство',
+    image: '🎨',
+    examples: ['The painting is colorful', 'She enjoys painting landscapes'],
+    pronunciation: 'ˈpeɪntɪŋ'
+  },
+  {
+    english: 'Forest',
+    russian: 'Лес',
+    category: 'Природа',
+    image: '🌳',
+    examples: ['The forest is quiet', 'We walked through the forest'],
+    pronunciation: 'ˈfɔːrɪst'
+  },
+  {
+    english: 'Journey',
+    russian: 'Путешествие',
+    category: 'Путешествия',
+    image: '🧭',
+    examples: ['Life is a journey', 'The journey took a week'],
+    pronunciation: 'ˈdʒɜːrni'
+  },
+  {
+    english: 'Music',
+    russian: 'Музыка',
+    category: 'Искусство',
+    image: '🎵',
+    examples: ['Music calms the mind', 'They love to play music'],
+    pronunciation: 'ˈmjuːzɪk'
+  },
+  {
+    english: 'Robot',
+    russian: 'Робот',
+    category: 'Технологии',
+    image: '🤖',
+    examples: ['The robot moves fast', 'Robots can help humans'],
+    pronunciation: 'ˈroʊˌbɑt'
+  },
+  {
+    english: 'Galaxy',
+    russian: 'Галактика',
+    category: 'Космос',
+    image: '🌌',
+    examples: ['The galaxy is vast', 'We saw a distant galaxy'],
+    pronunciation: 'ˈɡæləksi'
+  },
+  {
+    english: 'Teacher',
+    russian: 'Учитель',
+    category: 'Образование',
+    image: '👩‍🏫',
+    examples: ['The teacher explains well', 'She is a math teacher'],
+    pronunciation: 'ˈtiːtʃər'
+  }
+];
+
+export default autoWords;


### PR DESCRIPTION
## Summary
- expand emoji library for word icons
- add random word generator and button to quickly add words
- tweak list layout with circular progress and stacked translations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689b3aab607c8327b7c4ae1a7567f50b