### PR TITLE
feat: improve training results

### DIFF
--- a/src/styles/word-page.css
+++ b/src/styles/word-page.css
@@ -195,3 +195,21 @@
   background-color: #dbeafe;
 }
 
+/* Confetti animation */
+.confetti-piece {
+  position: fixed;
+  top: -10px;
+  width: 10px;
+  height: 10px;
+  opacity: 0.9;
+  pointer-events: none;
+  animation: confetti-fall 3s linear forwards;
+  z-index: 9999;
+}
+
+@keyframes confetti-fall {
+  to {
+    transform: translate3d(var(--end-x), 100vh, 0) rotate(720deg);
+  }
+}
+


### PR DESCRIPTION
## Summary
- count correct and incorrect words instead of tasks in trainer results
- add clickable word list with details modal and confetti celebration
- play audio cues for right and wrong answers and keep levels on mistakes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689b3e6ec45483278d0873f71c9cdbca