### PR TITLE
Improve word management UI and extend CSV import fields

### DIFF
--- a/src/AddWordForm.jsx
+++ b/src/AddWordForm.jsx
@@ -110,7 +110,7 @@ const AddWordForm = React.memo(({ newWord, handleNewWordChange, handleExampleCha
           disabled={!newWord.english || !newWord.russian}
           className="w-full bg-gradient-to-r from-blue-500 to-purple-600 text-white py-3 px-6 rounded-lg hover:from-blue-600 hover:to-purple-700 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          Добавить слово (+2 монеты)
+          Добавить (+2 монеты)
         </button>
       </div>
     </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -314,7 +314,7 @@ const defaultCategories = ['Разное', 'Путешествия', 'Приро
       const text = e.target.result;
       const lines = text.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
       const imported = lines.map(line => {
-        const [english, russian, category] = line.split(',').map(s => s.trim());
+        const [english, russian, category, pronunciation, example] = line.split(',').map(s => s.trim());
         if (!english || !russian) return null;
         return {
           id: Date.now() + Math.random(),
@@ -322,8 +322,8 @@ const defaultCategories = ['Разное', 'Путешествия', 'Приро
           russian,
           category: category || categoryOptions[0],
           image: '📝',
-          examples: [],
-          pronunciation: '',
+          examples: example ? [example] : [],
+          pronunciation: pronunciation || '',
           difficulty: 1,
           nextReview: Date.now(),
           reviewCount: 0,

--- a/src/WordsList.jsx
+++ b/src/WordsList.jsx
@@ -252,12 +252,6 @@ const WordsList = ({
                 </option>
               ))}
             </select>
-            <button
-              onClick={addCategory}
-              className="p-2 rounded-lg bg-gray-100 hover:bg-gray-200"
-            >
-              <FolderPlus className="w-5 h-5" />
-            </button>
             <select
               value={sortOption}
               onChange={(e) => setSortOption(e.target.value)}
@@ -278,6 +272,12 @@ const WordsList = ({
                 {viewMode === 'list' ? <LayoutGrid className="w-5 h-5" /> : <List className="w-5 h-5" />}
               </button>
               <button
+                onClick={addCategory}
+                className="p-2 rounded-lg bg-gray-100 hover:bg-gray-200"
+              >
+                <FolderPlus className="w-5 h-5" />
+              </button>
+              <button
                 onClick={generateWord}
                 className="bg-blue-500 text-white px-4 py-2 rounded-lg hover:bg-blue-600 transition-colors flex items-center gap-2"
               >
@@ -296,7 +296,7 @@ const WordsList = ({
                 className="bg-green-500 text-white px-4 py-2 rounded-lg hover:bg-green-600 transition-colors flex items-center gap-2"
               >
                 <Plus className="w-5 h-5" />
-                Добавить слово
+                Добавить
               </button>
             </div>
             {viewMode === 'list' && (
@@ -369,7 +369,7 @@ const WordsList = ({
               </button>
             </div>
             <p className="text-sm text-gray-600 mb-4">
-              Файл должен содержать колонки: английское слово, русский перевод, категория (необязательно). Каждая строка — отдельное слово.
+              Файл должен содержать колонки: английское слово, русский перевод, категория (необязательно), произношение (необязательно) и пример (необязательно). Каждая строка — отдельное слово.
             </p>
             <input
               type="file"


### PR DESCRIPTION
## Summary
- Simplify add word buttons to just “Добавить”
- Move category creation next to view mode switch
- Support pronunciation and example columns during CSV import

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b5c215e688327890475e2925d36f2