### PR TITLE
Refine word list UI and add pronunciation playback

### DIFF
--- a/src/AddWordForm.jsx
+++ b/src/AddWordForm.jsx
@@ -21,7 +21,7 @@ const AddWordForm = React.memo(({ newWord, handleNewWordChange, handleExampleCha
             type="text"
             value={newWord.english}
             onChange={(e) => handleNewWordChange('english', e.target.value)}
-            className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
             placeholder="Hello"
           />
         </div>
@@ -32,7 +32,7 @@ const AddWordForm = React.memo(({ newWord, handleNewWordChange, handleExampleCha
             type="text"
             value={newWord.russian}
             onChange={(e) => handleNewWordChange('russian', e.target.value)}
-            className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
             placeholder="Привет"
           />
         </div>
@@ -43,7 +43,7 @@ const AddWordForm = React.memo(({ newWord, handleNewWordChange, handleExampleCha
             type="text"
             value={newWord.pronunciation}
             onChange={(e) => handleNewWordChange('pronunciation', e.target.value)}
-            className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
             placeholder="he-ˈloʊ"
           />
         </div>
@@ -53,7 +53,7 @@ const AddWordForm = React.memo(({ newWord, handleNewWordChange, handleExampleCha
           <select
             value={newWord.category}
             onChange={(e) => handleNewWordChange('category', e.target.value)}
-            className="w-full pl-3 pr-8 py-2 rounded-lg bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 border-none"
+            className="w-full pl-3 pr-8 py-2 rounded-lg bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 border border-gray-300 appearance-none"
           >
             {categories.map(cat => (
               <option key={cat} value={cat}>{cat}</option>
@@ -93,14 +93,14 @@ const AddWordForm = React.memo(({ newWord, handleNewWordChange, handleExampleCha
             type="text"
             value={newWord.examples[0]}
             onChange={(e) => handleExampleChange(0, e.target.value)}
-            className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 mb-2"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 mb-2"
             placeholder="Hello, how are you?"
           />
           <input
             type="text"
             value={newWord.examples[1]}
             onChange={(e) => handleExampleChange(1, e.target.value)}
-            className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
             placeholder="Say hello to your friend"
           />
         </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1614,7 +1614,18 @@ const defaultCategories = ['Разное', 'Путешествия', 'Приро
                 <span>{word.image}</span>
               )}
             </div>
-            <h3 className="text-2xl font-bold text-center">{word.english}</h3>
+            <div className="flex items-center gap-2">
+              <h3 className="text-2xl font-bold text-center">{word.english}</h3>
+              <button
+                onClick={() => {
+                  const utterance = new SpeechSynthesisUtterance(word.english);
+                  speechSynthesis.speak(utterance);
+                }}
+                className="p-2 hover:bg-gray-100 rounded"
+              >
+                <Volume2 className="w-5 h-5" />
+              </button>
+            </div>
             {word.pronunciation && (
               <p className="text-gray-500">{word.pronunciation}</p>
             )}

--- a/src/EditWordForm.jsx
+++ b/src/EditWordForm.jsx
@@ -64,7 +64,7 @@ const EditWordForm = React.memo(({
           <select
             value={word.category}
             onChange={(e) => handleWordChange('category', e.target.value)}
-            className="w-full pl-3 pr-8 py-2 rounded-lg bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 border-none"
+            className="w-full pl-3 pr-8 py-2 rounded-lg bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 border border-gray-300 appearance-none"
           >
             {categories.map(cat => (
               <option key={cat} value={cat}>{cat}</option>

--- a/src/WordsList.jsx
+++ b/src/WordsList.jsx
@@ -120,18 +120,6 @@ const WordsList = ({
             <span className={`badge-base ${repeatClass}`}>{repeatText}</span>
           )}
         </div>
-        <div className="word-actions justify-center">
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              deleteWord(word.id);
-              setSelectedIds(prev => prev.filter(id => id !== word.id));
-            }}
-            className="icon-btn icon-danger"
-          >
-            <Trash2 className="w-5 h-5" />
-          </button>
-        </div>
       </div>
     );
   };
@@ -214,16 +202,6 @@ const WordsList = ({
           {word.level < maxLevel && (
             <span className={`badge-base ${repeatClass}`}>{repeatText}</span>
           )}
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              deleteWord(word.id);
-              setSelectedIds(prev => prev.filter(id => id !== word.id));
-            }}
-            className="icon-btn icon-danger"
-          >
-            <Trash2 className="w-5 h-5" />
-          </button>
           <input
             type="checkbox"
             checked={selectedIds.includes(word.id)}
@@ -268,7 +246,7 @@ const WordsList = ({
               <select
                 value={selectedCategory}
                 onChange={(e) => setSelectedCategory(e.target.value)}
-                className="pl-4 pr-8 py-2 rounded-lg bg-gray-100 text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 border-none"
+                className="pl-4 pr-8 py-2 rounded-lg bg-gray-100 text-gray-700 border border-gray-300 appearance-none focus:outline-none focus:ring-2 focus:ring-blue-500"
               >
                 {categories.map(cat => (
                   <option key={cat} value={cat}>
@@ -279,7 +257,7 @@ const WordsList = ({
               <select
                 value={sortOption}
                 onChange={(e) => setSortOption(e.target.value)}
-                className="pl-4 pr-8 py-2 rounded-lg bg-gray-100 text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 border-none"
+                className="pl-4 pr-8 py-2 rounded-lg bg-gray-100 text-gray-700 border border-gray-300 appearance-none focus:outline-none focus:ring-2 focus:ring-blue-500"
               >
                 <option value="date">По дате</option>
                 <option value="alpha">По алфавиту</option>
@@ -313,16 +291,16 @@ const WordsList = ({
                 </>
               )}
               <button
-                onClick={() => setViewMode(viewMode === 'list' ? 'grid' : 'list')}
-                className="p-2 rounded-lg bg-gray-100 hover:bg-gray-200"
-              >
-                {viewMode === 'list' ? <LayoutGrid className="w-5 h-5" /> : <List className="w-5 h-5" />}
-              </button>
-              <button
                 onClick={addCategory}
                 className="p-2 rounded-lg bg-gray-100 hover:bg-gray-200"
               >
                 <FolderPlus className="w-5 h-5" />
+              </button>
+              <button
+                onClick={() => setViewMode(viewMode === 'list' ? 'grid' : 'list')}
+                className="p-2 rounded-lg bg-gray-100 hover:bg-gray-200"
+              >
+                {viewMode === 'list' ? <LayoutGrid className="w-5 h-5" /> : <List className="w-5 h-5" />}
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Style select dropdowns with light gray borders and no arrows
- Highlight add-word inputs with light gray borders
- Remove per-word delete buttons, swap toolbar buttons, and add pronunciation playback to word details

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b61c25cd48327bc82f41ee881fa66