### PR TITLE
feat: confirm once when deleting multiple words

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -259,8 +259,8 @@ const defaultCategories = ['Разное', 'Путешествия', 'Приро
   }, [reviewWords, currentCardIndex, userStats.activeBoosts, updateWordProgress]);
 
   // Удаление слова
-  const deleteWord = useCallback((wordId) => {
-    if (window.confirm('Вы уверены, что хотите удалить это слово?')) {
+  const deleteWord = useCallback((wordId, confirm = true) => {
+    if (!confirm || window.confirm('Вы уверены, что хотите удалить это слово?')) {
       setWords(prev => {
         const updated = prev.filter(w => w.id !== wordId);
         saveWords(updated);

--- a/src/WordsList.jsx
+++ b/src/WordsList.jsx
@@ -77,8 +77,10 @@ const WordsList = ({
   const clearSelection = () => setSelectedIds([]);
 
   const deleteSelected = () => {
-    selectedIds.forEach(id => deleteWord(id));
-    setSelectedIds([]);
+    if (window.confirm(`Удалить выбранные слова (${selectedIds.length} шт.)?`)) {
+      selectedIds.forEach(id => deleteWord(id, false));
+      setSelectedIds([]);
+    }
   };
 
   const handleImportFile = (e) => {


### PR DESCRIPTION
## Summary
- ask for confirmation only once when deleting multiple selected words
- allow deleteWord to skip confirmation when invoked programmatically

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b69cd649c83278ea86a36e3751913